### PR TITLE
Add double quotes around `$@`

### DIFF
--- a/osx_app_path.sh
+++ b/osx_app_path.sh
@@ -44,5 +44,5 @@ osx_app_path() {
 
 # Run if not being sourced
 if [[ "$BASH_SOURCE" == "$0" ]]; then
-  osx_app_path $@
+  osx_app_path "$@"
 fi


### PR DESCRIPTION
Without double quotes around it, `$@` may break with spaces.

[More info](https://github.com/koalaman/shellcheck/wiki/SC2068).
Verified with [ShellCheck](http://www.shellcheck.net/).
